### PR TITLE
Add slice view arrows for staple strands

### DIFF
--- a/cadnano/gui/views/sliceview/activesliceitem.py
+++ b/cadnano/gui/views/sliceview/activesliceitem.py
@@ -24,8 +24,8 @@ class ActiveSliceItem(QGraphicsRectItem):
         part_item = self._part_item
         vhi = part_item.getVirtualHelixItemByCoord(*vh.coord())
         active_base_idx = part_item.part().activeBaseIndex()
-        is_active_now = vh.hasStrandAtIdx(active_base_idx)
-        vhi.setActiveSliceView(is_active_now, active_base_idx)
+        has_scaf, has_stap = vh.hasStrandAtIdx(active_base_idx)
+        vhi.setActiveSliceView(active_base_idx, has_scaf, has_stap)
     # end def
 
     def updateIndexSlot(self, sender, newActiveSliceZIndex):
@@ -37,8 +37,8 @@ class ActiveSliceItem(QGraphicsRectItem):
         for vhi in self._part_item._virtual_helix_hash.values():
             vh = vhi.virtualHelix()
             if vh:
-                is_active_now = vh.hasStrandAtIdx(active_base_idx)
-                vhi.setActiveSliceView(is_active_now, active_base_idx)
+                has_scaf, has_stap = vh.hasStrandAtIdx(active_base_idx)
+                vhi.setActiveSliceView(active_base_idx, has_scaf, has_stap)
     # end def
 
     def updateRectSlot(self, part):

--- a/cadnano/virtualhelix/virtualhelix.py
+++ b/cadnano/virtualhelix/virtualhelix.py
@@ -133,7 +133,10 @@ class VirtualHelix(ProxyObject):
     # end def
 
     def hasStrandAtIdx(self, idx):
-        return self._scaf_strandset.hasStrandAt(idx, idx)
+        """Return a tuple for (Scaffold, Staple). True if
+           a strand is present at idx, False otherwise."""
+        return (self._scaf_strandset.hasStrandAt(idx, idx),\
+                self._stap_strandset.hasStrandAt(idx, idx))
     # end def
 
     def indexOfRightmostNonemptyBase(self):


### PR DESCRIPTION
An additional arrow is now displayed in the slice view for staple strands that are present.
The angle is just 180° opposite the scaffold, but that can be improved in the future.
