### PR TITLE
Added forgotten distutils.sysconfig import

### DIFF
--- a/pyqt5_check.py
+++ b/pyqt5_check.py
@@ -1,5 +1,6 @@
 import sys
 import distutils
+import distutils.sysconfig
 import os
 import subprocess
 import platform


### PR DESCRIPTION
In some places, the submodule `distutils.sysconfig` is used, but its never imported. This errors out on my machine.