### PR TITLE
Cherry-picked changes to fix #39 onto feature branch for PR.

### DIFF
--- a/cadnano/document.py
+++ b/cadnano/document.py
@@ -16,6 +16,7 @@ from cadnano.virtualhelix import VirtualHelix
 from cadnano.part import Part
 from cadnano.part import HoneycombPart, SquarePart
 from cadnano.part import DnaPart
+from cadnano.part.origamipart import OrigamiPart
 from cadnano.objectinstance import ObjectInstance
 from cadnano.addinstancecmd import AddInstanceCommand
 from cadnano import app
@@ -41,12 +42,12 @@ class Document(ProxyObject):
         self._selected_changed_dict = {}
         app().documentWasCreatedSignal.emit(self)
     # end def
-            
+
     ### SIGNALS ###
-    documentPartAddedSignal =  ProxySignal(object, 
+    documentPartAddedSignal =  ProxySignal(object,
                                         ProxyObject,
                                         name='documentPartAddedSignal') # doc, part
-    documentAssemblyAddedSignal =  ProxySignal(object, 
+    documentAssemblyAddedSignal =  ProxySignal(object,
                                         ProxyObject,
                                         name='documentAssemblyAddedSignal') # doc, assembly
 
@@ -54,12 +55,12 @@ class Document(ProxyObject):
     # and the value is a tuple with meta data
     # in the case of strands the metadata would be which endpoints of selected
     # e.g. { objectRef: (value0, value1),  ...}
-    documentSelectedChangedSignal = ProxySignal(dict, 
+    documentSelectedChangedSignal = ProxySignal(dict,
                                         name='documentSelectedChangedSignal') # tuples of items + data
-    documentSelectionFilterChangedSignal = ProxySignal(list, 
+    documentSelectionFilterChangedSignal = ProxySignal(list,
                             name='documentSelectionFilterChangedSignal')
 
-    documentViewResetSignal = ProxySignal(ProxyObject, 
+    documentViewResetSignal = ProxySignal(ProxyObject,
                                             name='documentViewResetSignal')
     documentClearSelectionsSignal = ProxySignal(ProxyObject,
                                             name='documentClearSelectionsSignal')
@@ -152,7 +153,7 @@ class Document(ProxyObject):
     def selectionDict(self):
         return self._selection_dict
     # end def
-    
+
     def selectedOligos(self):
         """
         as long as one endpoint of a strand is in the selection, then the oligo
@@ -167,7 +168,7 @@ class Document(ProxyObject):
         # end for
         return selected_oligos if len(selected_oligos) > 0 else None
     #end def
-    
+
     def clearAllSelected(self):
         self._selection_dict = {}
         # the added list is what was recently selected or deselected
@@ -215,7 +216,7 @@ class Document(ProxyObject):
     # end def
 
     def determineStrandSetBounds(self, selected_strand_list, strandset):
-        
+
         length = strandset.length()
         min_high_delta = min_low_delta = max_ss_idx = length - 1 # init the return values
         ss_dict = self._selection_dict[strandset]
@@ -246,7 +247,7 @@ class Document(ProxyObject):
                     temp = idx_high - idx_low - 1
                     if temp < min_high_delta:
                         min_high_delta = temp
-                
+
             # end if
             if value[1]:
                 if high_neighbor is None:
@@ -301,7 +302,7 @@ class Document(ProxyObject):
         Delete selected strands. First iterates through all selected strands
         and extracts refs to xovers and strands. Next, calls removeXover
         on xoverlist as part of its own macroed command for isoluation
-        purposes. Finally, calls removeStrand on all strands that were 
+        purposes. Finally, calls removeStrand on all strands that were
         fully selected (low and high), or had at least one non-xover
         endpoint selected.
         """
@@ -331,7 +332,7 @@ class Document(ProxyObject):
         if use_undostack and xoList:
             self.undoStack().beginMacro("Delete xovers")
         for part, strand, strand3p, useUndo in xoList:
-            Part.removeXover(part, strand, strand3p, useUndo)
+            OrigamiPart.removeXover(part, strand, strand3p, useUndo)
             self.removeStrandFromSelection(strand)
             self.removeStrandFromSelection(strand3p)
         self._selection_dict = {}
@@ -450,28 +451,28 @@ class Document(ProxyObject):
     # end def
 
     ### PUBLIC METHODS FOR EDITING THE MODEL ###
-    def addHoneycombPart(self,  max_row=prefs.HONEYCOMB_PART_MAXROWS, 
-                                max_col=prefs.HONEYCOMB_PART_MAXCOLS, 
+    def addHoneycombPart(self,  max_row=prefs.HONEYCOMB_PART_MAXROWS,
+                                max_col=prefs.HONEYCOMB_PART_MAXCOLS,
                                 max_steps=prefs.HONEYCOMB_PART_MAXSTEPS):
         """
         Create and store a new origamipart and instance, and return the instance.
         """
         origamipart = None
         if len(self._children) == 0:
-            origamipart = HoneycombPart(document=self, max_row=max_row, 
+            origamipart = HoneycombPart(document=self, max_row=max_row,
                                 max_col=max_col, max_steps=max_steps)
             self._addPart(ObjectInstance(origamipart))
         return origamipart
 
-    def addSquarePart(self, max_row=prefs.SQUARE_PART_MAXROWS, 
-                            max_col=prefs.SQUARE_PART_MAXCOLS, 
+    def addSquarePart(self, max_row=prefs.SQUARE_PART_MAXROWS,
+                            max_col=prefs.SQUARE_PART_MAXCOLS,
                             max_steps=prefs.SQUARE_PART_MAXSTEPS):
         """
         Create and store a new origamipart and instance, and return the instance.
         """
         origamipart = None
         if len(self._children) == 0:
-            origamipart = SquarePart(document=self, max_row=max_row, 
+            origamipart = SquarePart(document=self, max_row=max_row,
                                 max_col=max_col, max_steps=max_steps)
             self._addPart(ObjectInstance(origamipart))
         return origamipart


### PR DESCRIPTION
The removeXover method was moved from the Part class to OrigamiPart class. However, document.py wasn't updated to reflect this change, producing tracebacks and making it impossible to delete strands and crossovers. This change to document.py (cherry-picked from commit 57a0f9011) fixes.

I'm doing this change as a separate feature branch, since my dev branch has a few too many other changes to make for a simple PR at the moment. This change is still removing trailing whitespaces, because they are annoy the hell out of me (and my editor removes them automatically). 

Would you be willing to merge a feature branch that removes all trailing whitespaces? (So we won't have to deal with that again?)
