### PR TITLE
Fix NameError: name prefs not defined in RemoveStrandCommand

### DIFF
--- a/cadnano/strandset/removestrandcmd.py
+++ b/cadnano/strandset/removestrandcmd.py
@@ -1,5 +1,6 @@
 from cadnano.cnproxy import UndoCommand
 from cadnano.strand import Strand
+import cadnano.preferences as prefs
 
 class RemoveStrandCommand(UndoCommand):
     """


### PR DESCRIPTION
cadnano.preferences is not imported in removestrandcmd.py causing:

Traceback (most recent call last):
  File "C:\cadnano files\cadnano2.5-master\cadnano\gui\views\pathview\pathselect
ion.py", line 135, in keyPressEvent
    self.selectionbox.deleteSelection()
  File "C:\cadnano files\cadnano2.5-master\cadnano\gui\views\pathview\pathselect
ion.py", line 464, in deleteSelection
    self._item_group.document().deleteSelection()
  File "C:\cadnano files\cadnano2.5-master\cadnano\document.py", line 336, in de
leteSelection
    strand.strandSet().removeStrand(strand)
  File "C:\cadnano files\cadnano2.5-master\cadnano\strandset\strandset.py", line
 224, in removeStrand
    cmds.append(RemoveStrandCommand(self, strand, strandset_idx, solo))
  File "C:\cadnano files\cadnano2.5-master\cadnano\strandset\removestrandcmd.py"
, line 32, in __init__
    colorList = prefs.STAP_COLORS if strandset.isStaple() else prefs.SCAF_COLORS

NameError: name 'prefs' is not defined