### PR TITLE
Using argparse to parse command line arguments

### DIFF
--- a/bin/main.py
+++ b/bin/main.py
@@ -28,6 +28,8 @@ def main(argv=None):
         import cProfile
         cProfile.runctx('app.exec_()', None, locals(), filename='cadnano.profile')
         print("Done collecting profile data. Use -P to print it out.")
+    if not app.argns.profile and not app.argns.print_stats:
+        sys.exit(app.exec_())
     if app.argns.print_stats:
         from pstats import Stats
         s = Stats('cadnano.profile')
@@ -39,7 +41,6 @@ def main(argv=None):
     #     print("running tests")
     #     from tests.runall import main as runTests
     #     runTests(useXMLRunner=False)
-    sys.exit(app.exec_())
 
 if __name__ == '__main__':
     main()

--- a/bin/main.py
+++ b/bin/main.py
@@ -18,16 +18,17 @@ to push GObject warnings to /dev/null on linux
 if "-t" in sys.argv:
     os.environ['CADNANO_IGNORE_ENV_VARS_EXCEPT_FOR_ME'] = 'YES'
 
-def main(args):
-    print(args)
+def main(argv=None):
+    print(argv)
     from cadnano import initAppWithGui
-    app = initAppWithGui(args)
-    if "-p" in args:
+    # Things are a lot easier if we can pass None instead of sys.argv and only fall back to sys.argv when we need to.
+    app = initAppWithGui(argv)
+    if app.argns.profile:
         print("Collecting profile data into cadnano.profile")
         import cProfile
         cProfile.runctx('app.exec_()', None, locals(), filename='cadnano.profile')
         print("Done collecting profile data. Use -P to print it out.")
-    elif "-P" in args:
+    if app.argns.print_stats:
         from pstats import Stats
         s = Stats('cadnano.profile')
         print("Internal Time Top 10:")
@@ -41,4 +42,4 @@ def main(args):
     sys.exit(app.exec_())
 
 if __name__ == '__main__':
-    main(sys.argv)
+    main()

--- a/cadnano/cadnanoqt.py
+++ b/cadnano/cadnanoqt.py
@@ -28,11 +28,12 @@ class CadnanoQt(QObject):
     documentWasCreatedSignal = pyqtSignal(object)  # doc
     documentWindowWasCreatedSignal = pyqtSignal(object, object)  # doc, window
 
-    def __init__(self, argv):
+    def __init__(self, argv=None):
         """ Create the application object
         """
+        self.argns, unused = util.parse_args(argv, gui=True)
         if argv is None:
-            argv = []
+            argv = sys.argv
         self.argv = argv
         if QCoreApplication.instance() is None:
             self.qApp = QApplication(argv)
@@ -74,7 +75,7 @@ class CadnanoQt(QObject):
         if os.environ.get('CADNANO_DEFAULT_DOCUMENT', False) and not self.ignoreEnv():
             self.shouldPerformBoilerplateStartupScript = True
         util.loadAllPlugins()
-        if "-i" in self.argv:
+        if self.argns.interactive:
             print("Welcome to cadnano's debug mode!")
             print("Some handy locals:")
             print("\ta\tcadnano.app() (the shared cadnano application object)")
@@ -124,7 +125,7 @@ class CadnanoQt(QObject):
 
     def newDocument(self, base_doc=None):
         global DocumentController
-        default_file = os.environ.get('CADNANO_DEFAULT_DOCUMENT', None)
+        default_file = self.argns.file or os.environ.get('CADNANO_DEFAULT_DOCUMENT', None)
         if default_file is not None and base_doc is not None:
             default_file = os.path.expanduser(default_file)
             default_file = os.path.expandvars(default_file)

--- a/cadnano/util.py
+++ b/cadnano/util.py
@@ -9,6 +9,7 @@ import sys
 import os
 from os import path
 import platform
+import argparse
 # import imp
 from itertools import dropwhile, starmap
 
@@ -241,3 +242,37 @@ def findChild(self):
         debugHighlighter.scene().removeItem(debugHighlighter)
         for child, wasVisible in childVisibility:
             child.setVisible(wasVisible)
+
+def parse_args(argv=None, gui=None):
+    """
+    Uses argparse to parse commandline args.
+    Returns a NameSpace object. This can easily be converted to a regular dict through:
+        argns.__dict__
+
+    This also presents a nice command line help to the user, exposed with --help flag:
+        python main.py --help
+
+    If gui is set to "qt", then the parser will use parse_known_args.
+    Unlike parse_args(), parse_known_args() will not cause abort by show the help message and exit,
+    if it finds any unrecognized command-line arguments.
+    Alternatively, you can initialize your app via
+        app = QApplication(sys.argv)
+        parse_args(app.arguments())
+    QApplication.arguments() returns a list of arguments with all Qt arguments stripped away.
+    Qt command line args include:
+        -style=<style> -stylesheet=<stylesheet> -widgetcount -reverse -qmljsdebugger -session=<session>
+    """
+    parser = argparse.ArgumentParser(description="Cadnano 2.5")
+    parser.add_argument("--testing", "-t", action="store_true", help="Enable testing mode/environment.")
+    parser.add_argument("--profile", "-p", action="store_true", help="Profile app execution.")
+    parser.add_argument("--print-stats", "-P", action="store_true", help="Print profiling statistics.")
+    parser.add_argument("--interactive", "-i", action="store_true", help="Enable interactive (console) mode.")
+    parser.add_argument('--loglevel',
+                        help="Specify logging level. Can be either DEBUG, INFO, WARNING, ERROR or any integer.")
+    parser.add_argument("--file", "-f", metavar="designfile.json", help="Cadnano design to load upon start up.")
+    if gui and (gui is True or gui.lower() == "qt"):
+        # Command line args might include Qt-specific switches and parameters.
+        argns, unused = parser.parse_known_args(argv)
+    else:
+        argns, unused = parser.parse_args(argv), None
+    return argns, unused


### PR DESCRIPTION
Can load a cadnano file from command line using bin/main.py -f <cadnano-file>. Profile and stats printing flags also works (-p/--profile and -P/--print-stats). Interactive mode (-i/--interactive) also works (yay) - but it is rather slow (on Windows).
