### PR TITLE
Logging system using standard logging library

### DIFF
--- a/bin/main.py
+++ b/bin/main.py
@@ -28,6 +28,8 @@ def main(argv=None):
         import cProfile
         cProfile.runctx('app.exec_()', None, locals(), filename='cadnano.profile')
         print("Done collecting profile data. Use -P to print it out.")
+    if not app.argns.profile and not app.argns.print_stats:
+        sys.exit(app.exec_())
     if app.argns.print_stats:
         from pstats import Stats
         s = Stats('cadnano.profile')
@@ -39,7 +41,6 @@ def main(argv=None):
     #     print("running tests")
     #     from tests.runall import main as runTests
     #     runTests(useXMLRunner=False)
-    sys.exit(app.exec_())
 
 if __name__ == '__main__':
     main()

--- a/bin/main.py
+++ b/bin/main.py
@@ -18,16 +18,17 @@ to push GObject warnings to /dev/null on linux
 if "-t" in sys.argv:
     os.environ['CADNANO_IGNORE_ENV_VARS_EXCEPT_FOR_ME'] = 'YES'
 
-def main(args):
-    print(args)
+def main(argv=None):
+    print(argv)
     from cadnano import initAppWithGui
-    app = initAppWithGui(args)
-    if "-p" in args:
+    # Things are a lot easier if we can pass None instead of sys.argv and only fall back to sys.argv when we need to.
+    app = initAppWithGui(argv)
+    if app.argns.profile:
         print("Collecting profile data into cadnano.profile")
         import cProfile
         cProfile.runctx('app.exec_()', None, locals(), filename='cadnano.profile')
         print("Done collecting profile data. Use -P to print it out.")
-    elif "-P" in args:
+    if app.argns.print_stats:
         from pstats import Stats
         s = Stats('cadnano.profile')
         print("Internal Time Top 10:")
@@ -41,4 +42,4 @@ def main(args):
     sys.exit(app.exec_())
 
 if __name__ == '__main__':
-    main(sys.argv)
+    main()

--- a/bin/main.py
+++ b/bin/main.py
@@ -2,6 +2,8 @@
 # encoding: utf-8
 import sys
 import os
+import logging
+logger = logging.getLogger(__name__)
 LOCAL_DIR = os.path.dirname(os.path.realpath(__file__))
 PROJECT_DIR = os.path.dirname(LOCAL_DIR)
 sys.path.append(PROJECT_DIR)

--- a/cadnano/cadnanoqt.py
+++ b/cadnano/cadnanoqt.py
@@ -28,11 +28,12 @@ class CadnanoQt(QObject):
     documentWasCreatedSignal = pyqtSignal(object)  # doc
     documentWindowWasCreatedSignal = pyqtSignal(object, object)  # doc, window
 
-    def __init__(self, argv):
+    def __init__(self, argv=None):
         """ Create the application object
         """
+        self.argns, unused = util.parse_args(argv, gui=True)
         if argv is None:
-            argv = []
+            argv = sys.argv
         self.argv = argv
         if QCoreApplication.instance() is None:
             self.qApp = QApplication(argv)
@@ -74,7 +75,7 @@ class CadnanoQt(QObject):
         if os.environ.get('CADNANO_DEFAULT_DOCUMENT', False) and not self.ignoreEnv():
             self.shouldPerformBoilerplateStartupScript = True
         util.loadAllPlugins()
-        if "-i" in self.argv:
+        if self.argns.interactive:
             print("Welcome to cadnano's debug mode!")
             print("Some handy locals:")
             print("\ta\tcadnano.app() (the shared cadnano application object)")
@@ -124,7 +125,7 @@ class CadnanoQt(QObject):
 
     def newDocument(self, base_doc=None):
         global DocumentController
-        default_file = os.environ.get('CADNANO_DEFAULT_DOCUMENT', None)
+        default_file = self.argns.file or os.environ.get('CADNANO_DEFAULT_DOCUMENT', None)
         if default_file is not None and base_doc is not None:
             default_file = os.path.expanduser(default_file)
             default_file = os.path.expandvars(default_file)

--- a/cadnano/cadnanoqt.py
+++ b/cadnano/cadnanoqt.py
@@ -1,5 +1,6 @@
 import sys, os
-
+import logging
+logger = logging.getLogger(__name__)
 from code import interact
 
 from cadnano.proxyconfigure import proxyConfigure
@@ -32,6 +33,8 @@ class CadnanoQt(QObject):
         """ Create the application object
         """
         self.argns, unused = util.parse_args(argv, gui=True)
+        util.init_logging(self.argns.__dict__)
+        logger.info("CadnanoQt initializing...")
         if argv is None:
             argv = sys.argv
         self.argv = argv
@@ -130,10 +133,12 @@ class CadnanoQt(QObject):
             default_file = os.path.expanduser(default_file)
             default_file = os.path.expandvars(default_file)
             dc = DocumentController(base_doc)
+            logger.info("Loading cadnano file %s to base document %s", default_file, base_doc)
             decodeFile(default_file, document=base_doc)
             print("Loaded default document: %s" % (default_file))
         else:
             doc_ctrlr_count = len(self.document_controllers)
+            logger.info("Creating new empty document...")
             if doc_ctrlr_count == 0:  # first dc
                 # dc adds itself to app.document_controllers
                 dc = DocumentController(base_doc)

--- a/cadnano/util.py
+++ b/cadnano/util.py
@@ -301,7 +301,7 @@ def init_logging(args=None, logdir=None):
             elif sys.platform == 'darwin':
                 logdir = os.path.join(os.path.expanduser("~"), "Library", "Logs", appname)
             else:
-                logdir = os.path.join(os.path.expanduser("~"), appname, "logs")
+                logdir = os.path.join(os.path.expanduser("~"), "."+appname, "logs")
     if not os.path.exists(logdir):
         os.makedirs(logdir)
     logfilepath = os.path.join(logdir, appname+".log")

--- a/cadnano/util.py
+++ b/cadnano/util.py
@@ -9,6 +9,7 @@ import sys
 import os
 from os import path
 import platform
+import argparse
 # import imp
 from itertools import dropwhile, starmap
 
@@ -241,3 +242,37 @@ def findChild(self):
         debugHighlighter.scene().removeItem(debugHighlighter)
         for child, wasVisible in childVisibility:
             child.setVisible(wasVisible)
+
+def parse_args(argv=None, gui=None):
+    """
+    Uses argparse to parse commandline args.
+    Returns a NameSpace object. This can easily be converted to a regular dict through:
+        argns.__dict__
+
+    This also presents a nice command line help to the user, exposed with --help flag:
+        python main.py --help
+
+    If gui is set to "qt", then the parser will use parse_known_args.
+    Unlike parse_args(), parse_known_args() will not cause abort by show the help message and exit,
+    if it finds any unrecognized command-line arguments.
+    Alternatively, you can initialize your app via
+        app = QApplication(sys.argv)
+        parse_args(app.arguments())
+    QApplication.arguments() returns a list of arguments with all Qt arguments stripped away.
+    Qt command line args include:
+        -style=<style> -stylesheet=<stylesheet> -widgetcount -reverse -qmljsdebugger -session=<session>
+    """
+    parser = argparse.ArgumentParser(description="Cadnano 2.5")
+    parser.add_argument("--testing", "-t", action="store_true", help="Enable testing mode/environment.")
+    parser.add_argument("--profile", "-p", action="store_true", help="Profile app execution.")
+    parser.add_argument("--print-stats", "-P", action="store_true", help="Print profiling statistics.")
+    parser.add_argument("--interactive", "-i", action="store_true", help="Enable interactive (console) mode.")
+    parser.add_argument('--loglevel',
+                        help="Specify logging level. Can be either DEBUG, INFO, WARNING, ERROR or any integer.")
+    parser.add_argument("--file", "-f", metavar="designfile.json", help="Cadnano design to load upon start up.")
+    if gui and (gui is True or gui.lower() == "qt"):
+        # Command line args might include Qt-specific switches and parameters.
+        argns, unused = parser.parse_known_args(argv)
+    else:
+        argns, unused = parser.parse_args(argv), None
+    return argns, unused

--- a/cadnano/util.py
+++ b/cadnano/util.py
@@ -10,6 +10,9 @@ import os
 from os import path
 import platform
 import argparse
+import logging
+import logging.handlers
+logger = logging.getLogger(__name__)
 # import imp
 from itertools import dropwhile, starmap
 
@@ -269,6 +272,10 @@ def parse_args(argv=None, gui=None):
     parser.add_argument("--interactive", "-i", action="store_true", help="Enable interactive (console) mode.")
     parser.add_argument('--loglevel',
                         help="Specify logging level. Can be either DEBUG, INFO, WARNING, ERROR or any integer.")
+    parser.add_argument("--debug-modules", nargs='*', metavar="MODULE-STR",
+                        help="Debug modules whose names start with any of the given strings. For instance, to "\
+                             "debug the cadnano file decoder, use --debug-modules cadnano.fileio.nnodecode ."\
+                             "To debug all gui modules, use --debug-modules cadnano.gui .")
     parser.add_argument("--file", "-f", metavar="designfile.json", help="Cadnano design to load upon start up.")
     if gui and (gui is True or gui.lower() == "qt"):
         # Command line args might include Qt-specific switches and parameters.
@@ -276,3 +283,84 @@ def parse_args(argv=None, gui=None):
     else:
         argns, unused = parser.parse_args(argv), None
     return argns, unused
+
+def init_logging(args=None, logdir=None):
+    """
+    Set up standard logging system based on parameters in args, e.g. loglevel and testing.
+    """
+    if args is None:
+        args = {}
+    if logdir is None:
+        appname = "cadnano"
+        try:
+            import appdirs
+            logdir = appdirs.user_log_dir(appname)
+        except ImportError:
+            if os.environ.get('APPDATA'):
+                logdir = os.path.join(os.environ['APPDATA'], appname, "Logs")
+            elif sys.platform == 'darwin':
+                logdir = os.path.join(os.path.expanduser("~"), "Library", "Logs", appname)
+            else:
+                logdir = os.path.join(os.path.expanduser("~"), appname, "logs")
+    if not os.path.exists(logdir):
+        os.makedirs(logdir)
+    logfilepath = os.path.join(logdir, appname+".log")
+
+    ## We want different output formatting for file vs console logging output.
+    ## File logs should be simple and easy to regex; console logs should be short and nice on the eyes
+    logfilefmt = '%(asctime)s %(levelname)-6s - %(name)s:%(lineno)s - %(funcName)s() - %(message)s'
+    logdatefmt = "%Y%m%d-%H:%M:%S"
+    loguserfmt = "%(asctime)s %(levelname)-5s %(name)30s:%(lineno)-4s%(funcName)16s() %(message)s"
+    loguserfmt = "%(asctime)s %(levelname)-5s %(module)30s:%(lineno)-4s%(funcName)16s() %(message)s"
+    logtimefmt = "%H:%M:%S" # Nice for output to user in console and testing.
+    # See https://docs.python.org/3/library/logging.html#logrecord-attributes for full list of attributes
+
+    # Loglevel (for console messages)
+    if args.get('loglevel'):
+        try:
+            loglevel = int(args['loglevel'])
+        except (TypeError, ValueError):
+            loglevel = getattr(logging, args['loglevel'].upper())
+    else:
+        loglevel = logging.DEBUG if args.get('testing') else logging.WARNING
+
+    if args.get('basic_logging', False):
+        logging.basicConfig(level=loglevel,
+                            format=loguserfmt,
+                            datefmt=logtimefmt,
+                            filename=logfilename)
+        logger.debug("Logging system initialized with loglevel %s", loglevel)
+    else:
+
+        # Set up custom logger:
+        logging.root.setLevel(logging.DEBUG)
+
+        # Add a rotating file handler:
+        logfilehandler = logging.handlers.RotatingFileHandler(logfilepath, maxBytes=2*2**20, backupCount=2)
+        logfileformatter = logging.Formatter(fmt=logfilefmt, datefmt=logdatefmt)
+        logfilehandler.setFormatter(logfileformatter)
+        logging.root.addHandler(logfilehandler)
+        print("Logging to file:", logfilepath)
+
+        # Add a custom StreamHandler for outputting to the console (default level is 0 = ANY)
+        logstreamhandler = logging.StreamHandler() # default stream is sys.stderr
+        logging.root.addHandler(logstreamhandler)
+        logstreamformatter = logging.Formatter(loguserfmt, logtimefmt)
+        logstreamhandler.setFormatter(logstreamformatter)
+
+        # Set filter for debugging:
+        if args.get('debug_modules'):
+            debug_modules = args['debug_modules']
+            def module_debug_filter(record):
+                """
+                All Filters attached to a logger or handler are asked.
+                The record is discarted if any of the attached Filters return False.
+                """
+                return any(record.name.startswith(modstr) for modstr in args['debug_modules']) \
+                    or record.levelno >= loglevel
+            logstreamhandler.addFilter(module_debug_filter)
+            # Default level is 0, which is appropriate when using module_debug_filter
+        else:
+            # only set a min level if we are not using module_debug_filter. (Level is an additional filter.)
+            logstreamhandler.setLevel(loglevel)
+    logger.info("Logging system initialized...")


### PR DESCRIPTION
Logging system using standard logging library.
 Default setup will log all messages at DEBUG and above to logfile on disk and only print WARNING/ERROR logging messages to the console. The console cutoff level can be controlled with --loglevel command line argument. To print all logging messages for just a few select modules, use the --debug-modules command line argument.

Default logfile locations are:
- Windows: %APPDATA%\cadnano\Logs
- OS X: ~/Library/Logs/cadnano
- Linux: ~/.cadnano/logs
  The code tries to use the "appdirs" module, and if that is not available, creates the proper logging directory path manually.
