### PR TITLE
Sequences can now be applied to staples as well as scaffold. 

### DIFF
--- a/cadnano/gui/views/pathview/strand/endpointitem.py
+++ b/cadnano/gui/views/pathview/strand/endpointitem.py
@@ -2,6 +2,8 @@
 # encoding: utf-8
 
 from math import floor
+import logging
+logger = logging.getLogger(__name__)
 from cadnano.gui.views.pathview import pathstyles as styles
 
 import cadnano.gui.views.pathview.pathselection as pathselection
@@ -270,7 +272,11 @@ class EndpointItem(QGraphicsPathItem):
         to the clicked strand via its oligo.
         """
         m_strand = self._strand_item._model_strand
-        if m_strand.isScaffold():
+        s_i = self._strand_item
+        viewroot = s_i.viewroot()
+        current_filter_dict = viewroot.selectionFilterDict()
+        if s_i.strandFilter() in current_filter_dict \
+                                    and self._filter_name in current_filter_dict:
             olgLen, seqLen = self._getActiveTool().applySequence(m_strand.oligo())
             if olgLen:
                 msg = "Populated %d of %d scaffold bases." % (min(seqLen, olgLen), olgLen)
@@ -281,6 +287,10 @@ class EndpointItem(QGraphicsPathItem):
                     d = seqLen - olgLen
                     msg = msg + " Warning: %d sequence bases unused." % d
                 self.partItem().updateStatusBar(msg)
+        else:
+            logger.info("The clicked strand %s does not match current selection filter %s. "\
+                        "strandFilter()=%s, _filter_name=%s", m_strand, current_filter_dict,
+                        s_i.strandFilter(), self._filter_name)
     # end def
 
     def modsToolMousePress(self, modifiers, event, idx):

--- a/cadnano/gui/views/pathview/strand/stranditem.py
+++ b/cadnano/gui/views/pathview/strand/stranditem.py
@@ -2,6 +2,8 @@
 # encoding: utf-8
 
 from math import floor
+import logging
+logger = logging.getLogger(__name__)
 from cadnano.gui.controllers.itemcontrollers.strand.stranditemcontroller import StrandItemController
 from .endpointitem import EndpointItem
 from cadnano.gui.views.pathview import pathstyles as styles
@@ -639,7 +641,8 @@ class StrandItem(QGraphicsLineItem):
         to the clicked strand via its oligo.
         """
         m_strand = self._model_strand
-        if m_strand.isScaffold():
+        current_filter_dict = self._viewroot.selectionFilterDict()
+        if self.strandFilter() in current_filter_dict and self._filter_name in current_filter_dict:
             olgLen, seqLen = self._getActiveTool().applySequence(m_strand.oligo())
             if olgLen:
                 msg = "Populated %d of %d scaffold bases." % (min(seqLen, olgLen), olgLen)
@@ -650,6 +653,10 @@ class StrandItem(QGraphicsLineItem):
                     d = seqLen - olgLen
                     msg = msg + " Warning: %d sequence bases unused." % d
                 self.partItem().updateStatusBar(msg)
+        else:
+            logger.info("The clicked strand %s does not match current selection filter %s. "\
+                        "strandFilter()=%s, _filter_name=%s", m_strand, current_filter_dict,
+                        self.strandFilter(), self._filter_name)
     # end def
 
     def restoreParent(self, pos=None):


### PR DESCRIPTION
This commit removes the m_strand.isScaffold() check in addSeqToolMousePress for endpointitem and stranditem gui modules. Instead, it is using the same selection filter that we already have for regular selection. (In the name of consistency and laziness). This change implements #45 and makes staples more "first class citizens", c.f. issue #49 . 

I don't think we have to worry about users being confused about the change in behaviour. After all, it is very obvious what happens, and they can easily re-apply the sequence to the scaffold should they accidentally apply a sequence to a staple strand the first time around. 

The only confusing thing right now is that the "selection filter gui panel" is not visible when the AddSeq tool is selected. I will try to fix this.
