### PR TITLE
Prevent signal connection failure in _addBasesClicked() method

### DIFF
--- a/cadnano/gui/views/pathview/origamipartitem.py
+++ b/cadnano/gui/views/pathview/origamipartitem.py
@@ -229,6 +229,21 @@ class OrigamiPartItem(QGraphicsRectItem):
 
     ### PRIVATE METHODS ###
     def _addBasesClicked(self):
+
+        @pyqtSlot(int)
+        def _addBasesCallback(n):
+            """
+            Given a user-chosen number of bases to add, snap it to an index
+            where index modulo stepsize is 0 and calls resizeVirtualHelices to
+            adjust to that size.
+            """
+            part = self._model_part
+            self._addBasesDialog.intValueSelected.disconnect(_addBasesCallback)
+            del self._addBasesDialog
+            maxDelta = n // part.stepSize() * part.stepSize()
+            part.resizeVirtualHelices(0, maxDelta)
+        # end def
+
         part = self._model_part
         step = part.stepSize()
         self._addBasesDialog = dlg = QInputDialog(self.window())
@@ -240,23 +255,12 @@ class OrigamiPartItem(QGraphicsRectItem):
         dlg.setLabelText(( "Number of bases to add to the existing"\
                          + " %i bases\n(must be a multiple of %i)")\
                          % (part.maxBaseIdx(), step))
-        dlg.intValueSelected.connect(self._addBasesCallback)
+        dlg.intValueSelected.connect(_addBasesCallback)
+
         dlg.open()
     # end def
 
-    @pyqtSlot(int)
-    def _addBasesCallback(self, n):
-        """
-        Given a user-chosen number of bases to add, snap it to an index
-        where index modulo stepsize is 0 and calls resizeVirtualHelices to
-        adjust to that size.
-        """
-        part = self._model_part
-        self._addBasesDialog.intValueSelected.disconnect(self._addBasesCallback)
-        del self._addBasesDialog
-        maxDelta = n // part.stepSize() * part.stepSize()
-        part.resizeVirtualHelices(0, maxDelta)
-    # end def
+
 
     def _removeBasesClicked(self):
         """


### PR DESCRIPTION
When you click on the arrow to expand the number of bases cadnano crash with the following error message : 

```
$ python bin/main.py 
None
Logging to file: /home/hadim/.cadnano/logs/cadnano.log
Test plugin loaded, has access to cadnano: <module 'cadnano' from './cadnano/__init__.py'>
partAddedSlot:  <HoneycombPart 3992> HoneycombPart
partAddedSlot:  <HoneycombPart 3848> HoneycombPart
QObject::connect: Cannot connect QInputDialog::intValueSelected(int) to (null)::_addBasesCallback(int)
Traceback (most recent call last):
  File "./cadnano/gui/views/pathview/origamipartitem.py", line 243, in _addBasesClicked
    dlg.intValueSelected.connect(self._addBasesCallback)
TypeError: connect() failed between intValueSelected(int) and _addBasesCallback()
Abandon
```

I have seen this in both Linux and Windows using PyQt 5.7 from pypi (https://pypi.python.org/pypi/PyQt5).

This PR fix the issue. If you find a better way, feel free to close this PR.
