### PR TITLE
Fix editing of the VirtualHelix 'z' Property

### DIFF
--- a/cadnano/gui/views/propertyview/virtualhelixitem.py
+++ b/cadnano/gui/views/propertyview/virtualhelixitem.py
@@ -7,9 +7,11 @@ Attributes:
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QTreeWidgetItem
 from PyQt5.QtWidgets import QDoubleSpinBox, QSpinBox
+
 from cadnano.cnenum import ItemType
 from cadnano.gui.controllers.itemcontrollers.virtualhelixitemcontroller import VirtualHelixItemController
 from .cnpropertyitem import CNPropertyItem
+
 
 KEY_COL = 0
 VAL_COL = 1
@@ -125,9 +127,9 @@ class VirtualHelixSetItem(CNPropertyItem):
                                                     'length'])
             editor.setRange(length, 4*length)
             editor.setSingleStep(bpr)
-        elif key == 'z' and self._model_part.isZEditable():
+        elif key == 'z' and cn_m.part().isZEditable():
             editor = QDoubleSpinBox(parent_QWidget)
-            bw = cm.part().baseWidth()
+            bw = cn_m.part().baseWidth()
             editor.setSingleStep(bw)
             editor.setRange(-bw*21, bw*21)
         else:

--- a/cadnano/part/virtualhelix.py
+++ b/cadnano/part/virtualhelix.py
@@ -96,7 +96,7 @@ class VirtualHelix(CNObject):
     def setZ(self, new_z, id_nums=None):
         m_p = self._part
         if id_nums is None:
-            id_nums = self._id_num
+            id_nums = [self._id_num]
 
         for id_num in id_nums:
             old_z = m_p.getVirtualHelixProperties(id_num, 'z')
@@ -104,6 +104,19 @@ class VirtualHelix(CNObject):
                 dz = new_z - old_z
                 m_p.translateVirtualHelices([id_num], 0, 0, dz, finalize=False, use_undostack=True)
     # end def
+
+    def getZ(self, id_num=None):
+        """Get the 'z' property of the VirtualHelix described by ID number
+        'id_num'.
+
+        If a VirtualHelix corresponding to id_num does not exist, an IndexError
+        will be thrown by getVirtualHelixProperties.
+        """
+        if __debug__:
+            assert isinstance(id_num, int) or id_num is None
+
+        return self._part.getVirtualHelixProperties(id_num if id_num is not None
+                else self._id_num, 'z')
 
     def getAxisPoint(self, idx):
         return self._part.getCoordinate(self._id_num, idx)

--- a/cadnano/util.py
+++ b/cadnano/util.py
@@ -13,6 +13,7 @@ import sys
 from os import path
 from traceback import extract_stack
 
+
 logger = logging.getLogger(__name__)
 
 IS_PY_3 = int(sys.version_info[0] > 2)
@@ -425,3 +426,35 @@ def read_fasta(fp):
             seq.append(line)
     if name:
         yield (name, ''.join(seq))
+
+
+def qtdb_trace():
+    """Make PDB usable by calling pyqtRemoveInputHook.
+
+    Otherwise, PDB is useless as the message
+    > QCoreApplication::exec: The event loop is already running
+    is spammed to the console.
+
+    When done, call qtdb_resume from the PDB prompt to return things back to
+    normal.
+
+    Note that PDB will drop you into the current frame (this function) and
+    hitting 'n' is required to return to the frame you wanted PDB originally.
+    This could probably be optimized at some point to manipulate the frame PDB
+    starts in.
+    """
+    import pdb
+    from PyQt5.QtCore import pyqtRemoveInputHook
+
+    pyqtRemoveInputHook()
+    pdb.set_trace()
+
+
+def qtdb_resume():
+    """Resume normal PyQt operations after calling qtdb_trace.
+
+    Note that this function assumes that pyqtRemoveInputHook has been called
+    """
+    from PyQt5.QtCore import pyqtRestoreInputHook
+
+    pyqtRestoreInputHook()


### PR DESCRIPTION
Fix the exception that was being thrown when attempting to edit the `z` property of a `VirtualHelix`.  Also add a couple functions (`qtdb_trace` and `qtdb_resume`) to `util.py` that make debugging with `pdb` possible.  This PR closes #96.

## Changes
### cadnano/gui/views/propertyview/virtualhelixitem.py:
**Error**
```
AttributeError: 'VirtualHelixSetItem' object has no attribute '_model_part'
```
**Fix**
`self._model_part` changed to `cn_m.part()`

------

**Error**
```
NameError: name 'cm' is not defined
```
**Fix**
`cm` changed to `cn_m`

### cadnano/part/virtualhelix.py:
**Error**
```
AttributeError: 'VirtualHelix' object has no attribute 'getZ'
```
**Fix**
Defined a `getZ` method to return the current `z` property value for the VirtualHelix corresponding to the given ID number

------

**Issue**
If `id_nums` is not set when calling `setZ`, the `setZ` method sets `id_nums` to `self._id_num`.  This will be problematic as the method goes on to iterate over `id_nums`, and `self._id_num` (which corresponds to an integer) is not iterable.  This may actually cause an exception, but this bug was fixed at the same time as `getZ` implementation, so no exception was seen by the developer for this bug

**Fix**
If `id_nums` is `None`, set `id_nums` to be a list of one element corresponding to the `VirtualHelix`'s `id_num`

-----

Also add spacing between 3p and local/library imports per PEP-8

### cadnano/util.py
Add `qtdb_trace` and `qtdb_resume` functions to `cadnano/util.py`.  These functions make PDB usable by removing and restoring the PyQt input hook when pausing and resuming program execution so that PDB can run.

If the standard `import pdb; pdb.set_trace()` is called without removing the input hook, the message
```
QCoreApplication::exec: The event loop is already running 
```
is spammed to the console.

Import and call `qtdb_trace` to start debugging at a certain point.  Note that, with the current implementation of qtdb_trace, PDB starts in the frame corresponding to the `qtdb_trace` function, so the developer will have to hit `n` once to get back to the correct frame.

```
>>> from cadnano.util import qtdb_trace, qtdb_resume
>>> ...
>>> qtdb_trace() # Stop program execution and start debugging here
```
Call `qtdb_resume()` from the `(Pdb)` prompt when ready to resume the program.  The developer will have to press `c` a couple times to break out of the `(Pdb)` prompt as well.

## Testing
Created a `VirtualHelix` and successfully updated its `z` property.  Saved to disk and manually verified that the updated `z` property is reflected in the output JSON.