### PR TITLE
only refresh segments if id_num exists

### DIFF
--- a/cadnano/fileio/v3decode.py
+++ b/cadnano/fileio/v3decode.py
@@ -77,7 +77,7 @@ def decodePart(document, part_dict, emit_signals=False):
                 low_idx, high_idx = idxs
                 rev_strand_set.createDeserializedStrand(low_idx, high_idx, color,
                                                         use_undostack=False)
-        part.refreshSegments(id_num)   # update segments
+            part.refreshSegments(id_num)   # update segments
     # end def
 
     xovers = part_dict['xovers']
@@ -193,6 +193,3 @@ def importToPart(part_instance, copy_dict, use_undostack=True):
 
     return new_vh_id_set
 # end def
-
-
-


### PR DESCRIPTION
When some of the virtual helices don't have strands, there are null/None entries in ['strands']['indices'] in the saved json file (via v3encode). Loading such a file yielded a bug because
part.refreshSegments(id_num)
was called with a nonexisting id_num.
Shifting this line into the if clause resolved the issue and made the file loadable.