### PR TITLE
2.5:  Fix the long-standing napart undo-redo bug

### DIFF
--- a/cadnano/part/nucleicacidpart.py
+++ b/cadnano/part/nucleicacidpart.py
@@ -96,7 +96,7 @@ class NucleicAcidPart(Part):
     __count = 0
     vh_editable_properties = VH_PROPERTY_KEYS.difference(set(['neighbors']))
 
-    # TODO[NF]:  Change usages of these strings to constants throughought files
+    # TODO[NF]:  Change usages of these strings to constants throughout files
     _FLOAT_PROPERTY_KEYS = [
         'bases_per_repeat',
         'bases_per_turn',

--- a/cadnano/views/gridview/tools/abstractgridtool.py
+++ b/cadnano/views/gridview/tools/abstractgridtool.py
@@ -34,7 +34,7 @@ class AbstractGridTool(QGraphicsObject):
         """
         # Setting parent to viewroot to prevent orphan _line_item from occurring
         super(AbstractGridTool, self).__init__(parent=manager.viewroot)
-        self.sgv = None
+        self.slice_graphics_view = None
         self.manager = manager
         self._active = False
         self._last_location = None
@@ -250,14 +250,14 @@ class AbstractGridTool(QGraphicsObject):
         if self._active and not will_be_active:
             self.deactivate()
         self._active = will_be_active
-        self.sgv = self.manager.window.grid_graphics_view
+        self.slice_graphics_view = self.manager.window.grid_graphics_view
         if hasattr(self, 'getCustomContextMenu'):
             # print("connecting ccm")
             try:    # Hack to prevent multiple connections
-                self.sgv.customContextMenuRequested.disconnect()
-            except Exception:
+                self.slice_graphics_view.customContextMenuRequested.disconnect()
+            except AttributeError:
                 pass
-            self.sgv.customContextMenuRequested.connect(self.getCustomContextMenu)
+            self.slice_graphics_view.customContextMenuRequested.connect(self.getCustomContextMenu)
     # end def
 
     def deactivate(self):
@@ -268,8 +268,8 @@ class AbstractGridTool(QGraphicsObject):
         """
         if hasattr(self, 'getCustomContextMenu'):
             # print("disconnecting ccm")
-            self.sgv.customContextMenuRequested.disconnect(self.getCustomContextMenu)
-        self.sgv = None
+            self.slice_graphics_view.customContextMenuRequested.disconnect(self.getCustomContextMenu)
+        self.slice_graphics_view = None
         self.is_started = False
         self.hideLineItem()
         self._vhi = None

--- a/cadnano/views/sliceview/tools/selectslicetool.py
+++ b/cadnano/views/sliceview/tools/selectslicetool.py
@@ -136,7 +136,7 @@ class SelectSliceTool(AbstractSliceTool):
             self.group.setParentItem(part_item)
 
             # required for whatever reason to renable QGraphicsView.RubberBandDrag
-            # TODO[NF]:  Determine why self.sgv is None when the dual-slice view is enabled
+            # TODO[NF]:  Determine why self.slice_graphics_view is None when the dual-slice view is enabled
             # TODO[NF]:  Now that SVG is being set properly, can the conditional be removed?
             # TODO[NF]:  This might be better kept as an error condition logged to logger.error
             if self.sgv is not None:


### PR DESCRIPTION
Fix the bug whereby creating a new lattice, undoing, and then clicking either lattice button or redoing would crash cadnano.

```
Traceback (most recent call last):
  File "./cadnano/views/gridview/gridrootitem.py", line 112, in clearSelectionsSlot
    self.select_tool.deselectItems()
  File "./cadnano/views/gridview/tools/selectgridtool.py", line 237, in deselectItems
    group.clearSelectionRect()
  File "./cadnano/views/gridview/tools/selectgridtool.py", line 488, in clearSelectionRect
    self.removeFromGroup(bri)
RuntimeError: wrapped C/C++ object of type GridSelectionGroup has been deleted
Abort trap: 6
```

In `setPartItem` of `SelectGridTool`, the parent of `self.group`, a `GridSelectionGroup`, would be set to the given parameter `part_item`.  This is problematic in the case of the bug, as the old part item would be garbage collected upon clicking either of the lattice buttons, as nothing would reference it anymore.  Because the parent of the `GridSelectionGroup` is the now un-referenced  
collected.  However, `self.group`, the owning reference to the `GridSelectionGroup` Python object, is still in scope and is therefore not garbage collected.

This change detects when this happens, and – when it does – creates a new `GridSelectionGroup`.