### PR TITLE
2.5:  Catch TypeError upon disconnect

### DIFF
--- a/cadnano/views/gridview/tools/selectgridtool.py
+++ b/cadnano/views/gridview/tools/selectgridtool.py
@@ -394,7 +394,7 @@ class SelectGridTool(AbstractGridTool):
         if self.slice_graphics_view is not None:
             try:
                 self.slice_graphics_view.rubberBandChanged.disconnect(self.selectRubberband)
-            except AttributeError:
+            except (AttributeError, TypeError):
                 pass    # required for first call
         self.modelClear()
         if self.snap_origin_item is not None:


### PR DESCRIPTION
`except Exception` was changed to `except AttributeError` in d13ffbf.  This block should also catch a `TypeError` (which is thrown less frequently).