### PR TITLE
2.5:  Fix TypeError in _inPointItem

### DIFF
--- a/cadnano/views/sliceview/nucleicacidpartitem.py
+++ b/cadnano/views/sliceview/nucleicacidpartitem.py
@@ -927,7 +927,7 @@ class SliceNucleicAcidPartItem(QAbstractPartItem):
         Returns:
             True if the mouse is in the given GridPoint, False otherwise
         """
-        if event_xy is None or event_coord is None:
+        if event_xy is None or event_coord is None or self.coordinates_to_xy.get(event_coord) is None:
             return False
 
         point_x, point_y = self.coordinates_to_xy.get(event_coord)


### PR DESCRIPTION
Fix the error

```
Traceback (most recent call last):
  File "./cadnano/views/customqgraphicsview.py", line 347, in keyReleaseEvent
    getattr(self.scene_root_item, KEY_RELEASE_EVENT)(event)
  File "./cadnano/views/sliceview/slicerootitem.py", line 197, in keyReleaseEvent
    getattr(na_part_item, 'keyReleaseEvent')(event)
  File "./cadnano/views/sliceview/nucleicacidpartitem.py", line 733, in keyReleaseEvent
    if self._inPointItem(self.last_mouse_position, self.getLastHoveredCoordinates()):
  File "./cadnano/views/sliceview/nucleicacidpartitem.py", line 933, in _inPointItem
    point_x, point_y = self.coordinates_to_xy.get(event_coord)
TypeError: 'NoneType' object is not iterable
Abort trap: 6
```

by short circuiting and aborting if the coordinates do not exist in the coordinate map