### PR TITLE
2.5.2:  Fix custom sequence input dialog

### DIFF
--- a/cadnano/views/pathview/tools/addseqtool.py
+++ b/cadnano/views/pathview/tools/addseqtool.py
@@ -261,10 +261,6 @@ class AddSeqTool(AbstractPathTool):
                 if not self.buttons[i].isChecked():
                     # Select the corresponding radio button for known sequence
                     self.buttons[i].click()
-            else:
-                # Unrecognized, Custom type
-                if not self.buttons[1].isChecked():
-                    self.buttons[1].click()
 
     def applySequence(self, oligo):
         """Summary


### PR DESCRIPTION
Prior to this change, an invalid sequence would result in the AddSeq tool automatically choosing the first predefined sequence.  This change removes this logic so that a custom sequence can be input into the custom dialog without jumping to another predefined sequence.