### PR TITLE
Use `mapToScene` in lieu of stored offsets

### DIFF
--- a/cadnano/views/sliceview/griditem.py
+++ b/cadnano/views/sliceview/griditem.py
@@ -549,6 +549,16 @@ class GridPoint(QGraphicsEllipseItem):
             part_item (TYPE):
             event (QGraphicsSceneMouseEvent): The event that the mouse click triggered
         """
+        print('GRIDITEM')
+        print('My parent is %s' % self.parentItem())
+        print('My grandparent is %s' % self.parentItem().parentItem())
+        print('Position:                  ', event.pos())
+        print('self.mapToScene:           ', self.mapToScene(event.pos().x(), event.pos().y()))
+        print('self.mapFromScene:         ', self.mapFromScene(event.pos().x(), event.pos().y()))
+        print('parent.mapToScene:         ', self.parentItem().mapToScene(event.pos().x(), event.pos().y()))
+        print('parent.mapFromScene:       ', self.parentItem().mapFromScene(event.pos().x(), event.pos().y()))
+        print('grandparent.mapToScene:    ', self.parentItem().parentItem().mapToScene(event.pos().x(), event.pos().y()))
+        print('grandparent.mapFromScene:  ', self.parentItem().parentItem().mapFromScene(event.pos().x(), event.pos().y()))
         part_item = self.grid.part_item
         tool = part_item._getActiveTool()
         if tool.FILTER_NAME not in part_item.part().document().filter_set:

--- a/cadnano/views/sliceview/griditem.py
+++ b/cadnano/views/sliceview/griditem.py
@@ -549,16 +549,6 @@ class GridPoint(QGraphicsEllipseItem):
             part_item (TYPE):
             event (QGraphicsSceneMouseEvent): The event that the mouse click triggered
         """
-        print('GRIDITEM')
-        print('My parent is %s' % self.parentItem())
-        print('My grandparent is %s' % self.parentItem().parentItem())
-        print('Position:                  ', event.pos())
-        print('self.mapToScene:           ', self.mapToScene(event.pos().x(), event.pos().y()))
-        print('self.mapFromScene:         ', self.mapFromScene(event.pos().x(), event.pos().y()))
-        print('parent.mapToScene:         ', self.parentItem().mapToScene(event.pos().x(), event.pos().y()))
-        print('parent.mapFromScene:       ', self.parentItem().mapFromScene(event.pos().x(), event.pos().y()))
-        print('grandparent.mapToScene:    ', self.parentItem().parentItem().mapToScene(event.pos().x(), event.pos().y()))
-        print('grandparent.mapFromScene:  ', self.parentItem().parentItem().mapFromScene(event.pos().x(), event.pos().y()))
         part_item = self.grid.part_item
         tool = part_item._getActiveTool()
         if tool.FILTER_NAME not in part_item.part().document().filter_set:

--- a/cadnano/views/sliceview/nucleicacidpartitem.py
+++ b/cadnano/views/sliceview/nucleicacidpartitem.py
@@ -673,7 +673,9 @@ class SliceNucleicAcidPartItem(QAbstractPartItem):
     # end def
 
     def hoverMoveEvent(self, event):
-        self.last_mouse_position = self.translateEventCoordinates(event)
+#        self.last_mouse_position = self.translateEventCoordinates(event)
+        mapped_position = self.griditem.mapFromScene(event.scenePos().x(), event.scenePos().y())
+        self.last_mouse_position = (mapped_position.x(), mapped_position.y())
         tool = self._getActiveTool()
         tool_method_name = tool.methodPrefix() + "HoverMove"
         if hasattr(self, tool_method_name):
@@ -742,8 +744,25 @@ class SliceNucleicAcidPartItem(QAbstractPartItem):
             event (TYPE): Description
             alt_event (None, optional): Description
         """
+        print('NAPART')
+        print('My parent is %s' % self.parentItem())
+        print('Position:               ', event.pos())
+        print('self.mapToScene:        ', self.mapToScene(event.pos().x(), event.pos().y()))
+        print('self.mapFromScene:      ', self.mapFromScene(event.pos().x(), event.pos().y()))
+        print('parent.mapToScene:      ', self.parentItem().mapToScene(event.pos().x(), event.pos().y()))
+        print('parent.mapFromScene:    ', self.parentItem().mapFromScene(event.pos().x(), event.pos().y()))
+        print('child.mapToScene:       ', self.griditem.mapToScene(event.pos().x(), event.pos().y()))
+        print('child.mapFromScene:     ', self.griditem.mapFromScene(event.pos().x(), event.pos().y()))
+        print('child.mapToScene:       ', self.griditem.mapToScene(event.scenePos().x(), event.scenePos().y()))
+        print('child.mapFromScene:     ', self.griditem.mapFromScene(event.scenePos().x(), event.scenePos().y()))
+
         # Abort if a VH already exists here
-        position = self.translateEventCoordinates(event)
+#        position = self.translateEventCoordinates(event)
+#        print('manually calculated:                        ', position)
+
+        mapped_position = self.griditem.mapFromScene(event.scenePos().x(), event.scenePos().y())
+        position = (mapped_position.x(), mapped_position.y())
+        print('manually calculated:                        ', (mapped_position.x(), mapped_position.y()))
 
         # 1. get point in model coordinates:
         part = self._model_part
@@ -886,7 +905,9 @@ class SliceNucleicAcidPartItem(QAbstractPartItem):
         Returns:
             TYPE: Description
         """
-        event_xy = self.translateEventCoordinates(event)
+#        event_xy = self.translateEventCoordinates(event)
+        mapped_position= self.griditem.mapFromScene(event.scenePos().x(), event.scenePos().y())
+        event_xy = (mapped_position.x(), mapped_position.y())
         event_coord = ShortestPathHelper.findClosestPoint(event_xy, self.coordinates_to_xy)
         is_alt = True if event.modifiers() & Qt.AltModifier else False
         self.last_mouse_position = event_xy

--- a/cadnano/views/sliceview/nucleicacidpartitem.py
+++ b/cadnano/views/sliceview/nucleicacidpartitem.py
@@ -59,9 +59,6 @@ class SliceNucleicAcidPartItem(QAbstractPartItem):
         self.spa_start_vhi = None
         self.last_mouse_position = None
 
-        self._translated_x = 0.0
-        self._translated_y = 0.0
-
         self._getActiveTool = viewroot.manager.activeToolGetter
         m_p = self._model_part
         self._controller = NucleicAcidPartItemController(self, m_p)
@@ -673,7 +670,6 @@ class SliceNucleicAcidPartItem(QAbstractPartItem):
     # end def
 
     def hoverMoveEvent(self, event):
-#        self.last_mouse_position = self.translateEventCoordinates(event)
         mapped_position = self.griditem.mapFromScene(event.scenePos().x(), event.scenePos().y())
         self.last_mouse_position = (mapped_position.x(), mapped_position.y())
         tool = self._getActiveTool()
@@ -744,25 +740,8 @@ class SliceNucleicAcidPartItem(QAbstractPartItem):
             event (TYPE): Description
             alt_event (None, optional): Description
         """
-        print('NAPART')
-        print('My parent is %s' % self.parentItem())
-        print('Position:               ', event.pos())
-        print('self.mapToScene:        ', self.mapToScene(event.pos().x(), event.pos().y()))
-        print('self.mapFromScene:      ', self.mapFromScene(event.pos().x(), event.pos().y()))
-        print('parent.mapToScene:      ', self.parentItem().mapToScene(event.pos().x(), event.pos().y()))
-        print('parent.mapFromScene:    ', self.parentItem().mapFromScene(event.pos().x(), event.pos().y()))
-        print('child.mapToScene:       ', self.griditem.mapToScene(event.pos().x(), event.pos().y()))
-        print('child.mapFromScene:     ', self.griditem.mapFromScene(event.pos().x(), event.pos().y()))
-        print('child.mapToScene:       ', self.griditem.mapToScene(event.scenePos().x(), event.scenePos().y()))
-        print('child.mapFromScene:     ', self.griditem.mapFromScene(event.scenePos().x(), event.scenePos().y()))
-
-        # Abort if a VH already exists here
-#        position = self.translateEventCoordinates(event)
-#        print('manually calculated:                        ', position)
-
         mapped_position = self.griditem.mapFromScene(event.scenePos().x(), event.scenePos().y())
         position = (mapped_position.x(), mapped_position.y())
-        print('manually calculated:                        ', (mapped_position.x(), mapped_position.y()))
 
         # 1. get point in model coordinates:
         part = self._model_part
@@ -905,7 +884,6 @@ class SliceNucleicAcidPartItem(QAbstractPartItem):
         Returns:
             TYPE: Description
         """
-#        event_xy = self.translateEventCoordinates(event)
         mapped_position= self.griditem.mapFromScene(event.scenePos().x(), event.scenePos().y())
         event_xy = (mapped_position.x(), mapped_position.y())
         event_coord = ShortestPathHelper.findClosestPoint(event_xy, self.coordinates_to_xy)
@@ -1044,42 +1022,6 @@ class SliceNucleicAcidPartItem(QAbstractPartItem):
         """
         assert isinstance(point_map, dict)
         self.coordinates_to_xy = point_map
-    # end def
-
-    def updateTranslatedOffsets(self, delta_x, delta_y):
-        """
-        Update the values used to calculate translational offsets.
-
-        Args:
-            delta_x (float):  the new value for which we've translated in the x
-                direction
-            delta_y (float):  the new value for which we've translated in the y
-                direction
-
-        Returns:
-            None
-        """
-        assert isinstance(delta_x, float)
-        assert isinstance(delta_y, float)
-
-        self._translated_x = delta_x
-        self._translated_y = delta_y
-    # end def
-
-    def translateEventCoordinates(self, event):
-        """
-        Given an event, return the x-y coordinates of the event accounting for
-        any translations that may have happened
-
-        Args:
-            event (MousePressEvent):  the event for which x-y coordinates should
-                be returned
-
-        Returns:
-            A tuple of x-y coordinates of the event
-        """
-        assert isinstance(event, QGraphicsSceneEvent)
-        return event.scenePos().x() - self._translated_x, event.scenePos().y() - self._translated_y
     # end def
 
     def removeAllCreateHints(self):

--- a/cadnano/views/sliceview/slicerootitem.py
+++ b/cadnano/views/sliceview/slicerootitem.py
@@ -200,10 +200,3 @@ class SliceRootItem(QGraphicsRectItem):
         for na_part_item in self.instance_items:
             if hasattr(na_part_item, 'keyReleaseEvent'):
                 getattr(na_part_item, 'keyReleaseEvent')(event)
-
-    def setTransform(self, QTransform, combine=False):
-        super(SliceRootItem, self).setTransform(QTransform, combine=False)
-        delta_x = QTransform.m31()
-        delta_y = QTransform.m32()
-        for na_part_item in self.instance_items:
-            na_part_item.updateTranslatedOffsets(delta_x, delta_y)


### PR DESCRIPTION
Instead of using the stored offsets from translating the `sliceRootItem`, use the built-in `mapToScene` methods.  