### PR TITLE
Add Pre-Commit Hook and Documentation Updates

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -113,7 +113,9 @@ exclude_patterns = ['_build',
                     'api/cadnano.controllers.documentcontroller.rst',
                     'api/cadnano.gui.mainwindow.ui_mainwindow.rst',
                     'api/cadnano.views.documentwindow.rst',
-                    'api/cadnano.views.outlinerview.outlinertreewidget.rst'
+                    'api/cadnano.views.outlinerview.outlinertreewidget.rst',
+                    'api/cadnano.views.pathview.tools.addseqtool.rst',
+                    'api/cadnano.views.pathview.tools.pathtoolmanager.rst'
                     ]
 
 # The reST default role (used for this markup: `text`) to use for all

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -75,6 +75,8 @@ For the sake of consistency and leveraging core sphinx features, we initially ju
 
 ## Known Issues
 
+**toctree Warnings**
+
 When building the docs, you may see warnings like:
 
 ```
@@ -85,6 +87,24 @@ WARNING: toctree contains reference to nonexisting document 'api/cadnano.views.o
 ```
 
 These modules import the PyQt5 classes in a way that doesn't play nicely with sphinx, so they are specifically excluded in `docs/conf.py`. Consequently, the documentation for these modules will be missing until someone tracks down the root cause of this issue and figures out a workaround. Possible starting point: [stackoverflow.com/questions/25960309/](http://stackoverflow.com/questions/25960309/)
+
+**segfaults**
+
+You may see segfaults when trying to run `make html` or `make livehtml` that
+look like this:
+```
+...
+reading sources... [ 70%] api/cadnano.views.pathview.strand.stranditem
+reading sources... [ 71%] api/cadnano.views.pathview.strand.xoveritem
+reading sources... [ 71%] api/cadnano.views.pathview.tools
+reading sources... [ 72%] api/cadnano.views.pathview.tools.abstractpathtool
+reading sources... [ 72%] api/cadnano.views.pathview.tools.addseqtool
+make: *** [html] Segmentation fault: 11
+```
+
+If you encounter this, you may need to exclude the offending source from the
+build.  Add the last source read before the segfault to the `exclude_patterns`
+list in `conf.py`.  Ensure that you include the trailing `.rst` in the string.
 
 
 ## Contributing

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ Welcome to cadnano's documentation!
 
    api
    docs
+   tests
    gui
    changelog
    authors

--- a/docs/shortcuts.rst
+++ b/docs/shortcuts.rst
@@ -9,8 +9,8 @@ Keyboard Shortcuts
     New           ⌘N
     Open          ⌘O
     Close         ⌘W
-    Save          ⇧⌘S
-    SaveAs        ⌘W
+    Save          ⌘S
+    SaveAs        ⌘⇧S
   
   Tools:
     CreateTool    C

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -17,7 +17,7 @@ committed will always pass the test suite.
 A script to accomplish this when committing via the `git` command line is
 included in this repository.  To activate it, run
 ```
-ln -s "$(git rev-parse --show-toplevel)/misc/git-hooks/pre-commit" .git/hooks/
+ln -s "$(git rev-parse --show-toplevel)/misc/git-hooks/pre-commit" $(git rev-parse --show-toplevel)/.git/hooks/
 ```
 anywhere in the cadnano repository.  This will symlink the pre-commit hook to
 your `.git/hooks` directory.  Now, whenever you commit, the test suite will be

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -1,0 +1,74 @@
+# Tests
+
+## Running Tests Locally
+
+To run tests locally, run
+```
+pytest cadnano/tests
+```
+from the repository root.
+
+## Automating Tests with a Pre-Commit Hook
+
+Pre-commit hooks are a great way to make sure that something is done (e.g. the
+test suite is run) before committing.  Doing this ensures that code that is
+committed will always pass the test suite.
+
+A script to accomplish this when committing via the `git` command line is
+included in this repository.  To activate it, run
+```
+ln -s "$(git rev-parse --show-toplevel)/misc/git-hooks/pre-commit" .git/hooks/
+```
+anywhere in the cadnano repository.  This will symlink the pre-commit hook to
+your `.git/hooks` directory.  Now, whenever you commit, the test suite will be
+run before you commit:
+
+```
+❱ git commit
+Running tests in $HOME/cadnano2.5/cadnano/tests...
+
+============================== test session starts ==============================
+platform darwin -- Python 3.6.3, pytest-3.3.1, py-1.5.2, pluggy-0.6.0
+PyQt5 5.9.2 -- Qt runtime 5.9.3 -- Qt compiled 5.9.3
+rootdir: $HOME/cadnano2.5/cadnano/tests, inifile: pytest.ini
+plugins: qt-2.3.0
+collected 12 items
+
+cadnano/tests/functionaltest.py .......                                    [ 58%]
+cadnano/tests/nucleicacidparttest.py ....                                  [ 91%]
+cadnano/tests/strandsettest.py .                                           [100%]
+
+=========================== 12 passed in 1.47 seconds ===========================
+```
+
+and if any of the tests fail, committing will be blocked:
+
+```
+Running tests in $HOME/cadnano2.5/cadnano/tests...
+
+============================== test session starts ==============================
+platform darwin -- Python 3.6.3, pytest-3.3.1, py-1.5.2, pluggy-0.6.0
+PyQt5 5.9.2 -- Qt runtime 5.9.3 -- Qt compiled 5.9.3
+rootdir: $HOME/cadnano2.5/cadnano/tests, inifile: pytest.ini
+plugins: qt-2.3.0
+collected 5 items / 1 errors
+
+==================================== ERRORS =====================================
+______________________ ERROR collecting functionaltest.py _______________________
+cadnano-virtualenv/lib/python3.6/site-packages/_pytest/python.py:403: in _importtestmodule
+    mod = self.fspath.pyimport(ensuresyspath=importmode)
+cadnano-virtualenv/lib/python3.6/site-packages/py/_path/local.py:668: in pyimport
+    __import__(modname)
+E     File "$HOME/cadnano2.5/cadnano/tests/functionaltest.py", line 14
+E       def
+E         ^
+E   SyntaxError: invalid syntax
+!!!!!!!!!!!!!!!!!!!! Interrupted: 1 errors during collection !!!!!!!!!!!!!!!!!!!!
+============================ 1 error in 0.68 seconds ============================
+
+Tests failed; commit aborted
+To commit without this hook running, pass the --no-verify argument
+```
+
+As the last line says, if you want to ignore the fact that tests are failing and
+commit anyway, pass the `--no-verify` argument to `git commit`.

--- a/misc/git-hooks/pre-commit
+++ b/misc/git-hooks/pre-commit
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+function abort() {
+    echo
+    echo $1
+    echo 'To commit without this hook running, pass the --no-verify argument'
+    exit 1
+}
+
+function success() {
+    echo 'Tests passed.'
+}
+
+BASE=$(git rev-parse --show-toplevel)
+
+echo "Running tests in $BASE/cadnano/tests..."
+echo
+
+pytest $BASE/cadnano/tests
+
+if [ $? -ne 0 ]; then
+    abort 'Tests failed; commit aborted'
+else
+    exit 0
+fi


### PR DESCRIPTION
Add a pre-commit hook so that tests can be automatically run before committing.  This can be accomplished by running
```
ln -s "$(git rev-parse --show-toplevel)/misc/git-hooks/pre-commit" $(git rev-parse --show-toplevel)/.git/hooks/
```
anywhere in the project repository.  This command creates a symlink from the `pre-commit` script to `.git/hooks`

When `git commit` is run on the command line (and on GitHub Desktop, at least according to a number of closed issues for GitHub Desktop) the pre-commit hook will run and block committing until tests pass.  This restriction can be bypassed by adding the `--no-verify` flag (or `-n`) when running `git commit`.

Also update documentation so that `make html` actually runs without segfaulting.  Document the workaround for this behavior in `docs.rst` as well.

Added a new documentation page called `tests` that outlines how this works.  
![documentation](https://user-images.githubusercontent.com/2508133/35366746-cf303286-012f-11e8-823c-e8972f29df26.png)