### PR TITLE
Fix logic to determine if path view is visible

### DIFF
--- a/cadnano/views/documentwindow.py
+++ b/cadnano/views/documentwindow.py
@@ -276,7 +276,7 @@ class DocumentWindow(QMainWindow, ui_mainwindow.Ui_MainWindow):
         # self.action_grid.setChecked(console_visible)
         inspector_visible = self.inspector_dock_widget.isVisibleTo(self)
         self.action_inspector.setChecked(inspector_visible)
-        path_visible = self.slice_dock_widget.widget().isVisibleTo(self)
+        path_visible = self.path_dock_widget.isVisibleTo(self)
         self.action_path.setChecked(path_visible)
         slice_visible = self.slice_dock_widget.isVisibleTo(self)
         self.action_slice.setChecked(slice_visible)


### PR DESCRIPTION
When the path view is hidden, cadnano is closed, and cadnano is reopened, the button to toggle the path view is inverted.  

This but is similar (but not the same) as the bug fixed in #148 except that it applies to the path view rather than the inspector.  