### PR TITLE
Fix bug whereby sliceview_idx was a string

### DIFF
--- a/cadnano/views/preferences.py
+++ b/cadnano/views/preferences.py
@@ -48,7 +48,7 @@ class Preferences(object):
         """
         self.qs.beginGroup(PREFS_GROUP_NAME)
         self.gridview_style_idx = self.qs.value(GRIDVIEW_STYLE_KEY, GRIDVIEW_STYLE_DEFAULT)
-        self.sliceview_idx = self.qs.value(SLICEVIEW_KEY, SLICEVIEW_DEFAULT)
+        self.sliceview_idx = int(self.qs.value(SLICEVIEW_KEY, SLICEVIEW_DEFAULT))   # TODO[NF]:  Investigate QSettings `0` vs `'0'`
         self.zoom_speed = self.qs.value(ZOOM_SPEED_KEY, ZOOM_SPEED_DEFAULT)
         self.show_icon_labels = self.qs.value(SHOW_ICON_LABELS_KEY, SHOW_ICON_LABELS_DEFAULT)
         self.qs.endGroup()


### PR DESCRIPTION
Despite not seeing this preference ever being set as a string, `QSettings` thinks that this value is a string on a Linux system.  Toggling the stored value in the GUI via preferences still results in this value being retrieved as a string.  

This was reproducible only on a system running Linux; it looks like there might be an issue with how preferences are stored.

Adding this patch so that other updates can be integrated on this system.

This PR corresponds to a single commit extracted from #156 