### PR TITLE
Fix Crashing Upon Load of a File Designed w/out a Workplane

### DIFF
--- a/cadnano/fileio/v3decode.py
+++ b/cadnano/fileio/v3decode.py
@@ -165,9 +165,10 @@ def decodePart(document, part_dict, grid_type, emit_signals=False):
                 'crossover_span_angle',
                 'max_vhelix_length',
                 'workplane_idxs']:
-        value = part_dict[key]
-        part.setProperty(key, value, use_undostack=False)
-        part.partPropertyChangedSignal.emit(part, key, value)
+        value = part_dict.get(key)
+        if value:
+            part.setProperty(key, value, use_undostack=False)
+            part.partPropertyChangedSignal.emit(part, key, value)
 # end def
 
 

--- a/cadnano/fileio/v3decode.py
+++ b/cadnano/fileio/v3decode.py
@@ -166,7 +166,7 @@ def decodePart(document, part_dict, grid_type, emit_signals=False):
                 'max_vhelix_length',
                 'workplane_idxs']:
         value = part_dict.get(key)
-        if value:
+        if value is not None:
             part.setProperty(key, value, use_undostack=False)
             part.partPropertyChangedSignal.emit(part, key, value)
 # end def


### PR DESCRIPTION
This change fixes a bug whereby loading a design that was designed with a version of cadnano that did not include a `workplane` would crash the app.

Rather than assuming that a key exists, do a `dict.get` on the key and abort setting the given property if the key corresponding to that property isn't found.

This PR corresponds to a single commit extracted from #156