### PR TITLE
Implement copying and pasting in the SliceView

### DIFF
--- a/cadnano/fileio/lattice.py
+++ b/cadnano/fileio/lattice.py
@@ -52,8 +52,8 @@ class HoneycombDnaPart(object):
     # end def
 
     @staticmethod
-    def distanceFromClosestLatticeCoord(radius: float,
-                                        x: float, y: float,
+    def distanceFromClosestLatticeCoord(x: float, y: float,
+                                        radius: float,
                                         scale_factor: float = 1.0) -> Vec2T:
         """Given a x and y position, determine closest lattice coordinate and
         the distance to the center of those coordinates.

--- a/cadnano/fileio/v3decode.py
+++ b/cadnano/fileio/v3decode.py
@@ -235,9 +235,10 @@ def decodePart( document: DocT,
                 'crossover_span_angle',
                 'max_vhelix_length'
                 ):
-        value = part_dict[key]
-        part.setProperty(key, value, use_undostack=False)
-        part.partPropertyChangedSignal.emit(part, key, value)
+        value = part_dict.get(key)
+        if value is not None:
+            part.setProperty(key, value, use_undostack=False)
+            part.partPropertyChangedSignal.emit(part, key, value)
 # end def
 
 
@@ -259,8 +260,6 @@ def importToPart(   part_instance : ObjectInstance,
     """
     assert isinstance(offset, (tuple, list)) or offset is None
     assert isinstance(use_undostack, bool)
-
-    # print('Importing to part where use_undostack is %s' % use_undostack)
 
     part = part_instance.reference()
     if use_undostack:
@@ -331,7 +330,6 @@ def importToPart(   part_instance : ObjectInstance,
         if i not in copied_vh_index_set:
             continue
         if idx_set is not None:
-            # print("getting", new_id_num)
             fwd_strand_set, rev_strand_set = part.getStrandSets(i + id_num_offset)
             fwd_idxs, rev_idxs = idx_set
             fwd_colors, rev_colors = color_list[i]

--- a/cadnano/views/propertyview/propertyeditorwidget.py
+++ b/cadnano/views/propertyview/propertyeditorwidget.py
@@ -151,8 +151,6 @@ class PropertyEditorWidget(QTreeWidget):
         item_types = set([item.itemType() for item in selected_items])
         num_types = len(item_types)
         if num_types != 1:  # assume no mixed types for now
-            # print("outlinerItemSelectionChanged returning1")
-            # print(item_types)
             return
         item_type = item_types.pop()
         outline_view_obj_list = [item.outlineViewObj() for item in selected_items if item.isSelected()]

--- a/cadnano/views/sliceview/nucleicacidpartitem.py
+++ b/cadnano/views/sliceview/nucleicacidpartitem.py
@@ -1113,6 +1113,7 @@ class SliceNucleicAcidPartItem(QAbstractPartItem):
         # placing clipboard's min_id_same_parity on the hovered_coord,
         # hint neighboring coords with offsets corresponding to clipboard vhs
         hinted_coordinates = []
+        copied_coordinates = []
         for i in range(len(vh_id_list)):
             vh_id, vh_len = vh_id_list[i]
             position_xy = part.locationQt(vh_id, self.scaleFactor())
@@ -1122,11 +1123,14 @@ class SliceNucleicAcidPartItem(QAbstractPartItem):
                                                             self.scale_factor)
             hint_coord = (hov_row+(copied_row-min_row), hov_col+(copied_col-min_col))
             hinted_coordinates.append(hint_coord)
+            copied_coordinates.append((copied_row, copied_col))
 
         # If any of the highlighted coordinates conflict with any existing VHs, abort
         if any(coord in self.coordinates_to_vhid.keys() for coord in hinted_coordinates):
+            print('Conflict')
             self.copypaste_origin_offset = None
             return
+        print(self.coordinates_to_vhid)
 
         for i, hint_coord in enumerate(hinted_coordinates):
             self.griditem.showCreateHint(hint_coord, next_idnums=(i+id_offset, i+id_offset))

--- a/cadnano/views/sliceview/tools/selectslicetool.py
+++ b/cadnano/views/sliceview/tools/selectslicetool.py
@@ -382,7 +382,7 @@ class SelectSliceTool(AbstractSliceTool):
             return
 
         doc.undoStack().beginMacro("Paste VirtualHelices")
-        new_vh_set = v3decode.importToPart(part_instance, self.clipboard, offset, ignore_neighbors=True)
+        new_vh_set = v3decode.importToPart(part_instance, self.clipboard, offset)
         doc.undoStack().endMacro()
         self.modelClear()
         self.clipboard = None


### PR DESCRIPTION
Enable copying and pasting in the SliceView.  When the select tool is selected, copying a VH or group of VHs copies the VH(s) to a buffer and shows a preview of what the pasted VHs will look like.

Pasting ensures that the VHs are pasted in the correct position for their parity.  Furthermore, pasting (either via clicking or via the context menu) is disabled if pasting would be illegal (i.e. if pasting would result in a VH being placed on top of another VH).

This PR includes changes made in #156.  It also includes a commit from #161 as these changes build on changes in #161.