### PR TITLE
Fix SPA mode

### DIFF
--- a/cadnano/part/nucleicacidpart.py
+++ b/cadnano/part/nucleicacidpart.py
@@ -2785,6 +2785,8 @@ class NucleicAcidPart(Part):
         assert length is None or len(length) == len(x_list)
         assert properties_list is None or isinstance(properties_list, (list, tuple))
         assert properties_list is None or len(properties_list) == len(x_list)
+        assert id_nums is None or isinstance(id_nums, list)
+        assert id_nums is None or len(id_nums) == len(x_list)
         assert safe_list is None or isinstance(safe_list, (list, tuple))
         assert safe_list is None or len(safe_list) == len(x_list)
         assert isinstance(use_undo_stack, bool)

--- a/cadnano/part/nucleicacidpart.py
+++ b/cadnano/part/nucleicacidpart.py
@@ -2783,8 +2783,6 @@ class NucleicAcidPart(Part):
         assert z_list is None or len(z_list) == len(x_list)
         assert length is None or isinstance(length, (list, tuple))
         assert length is None or len(length) == len(x_list)
-        assert id_num is None or isinstance(id_num, (list, tuple))
-        assert id_num is None or len(id_num) == len(x_list)
         assert properties_list is None or isinstance(properties_list, (list, tuple))
         assert properties_list is None or len(properties_list) == len(x_list)
         assert safe_list is None or isinstance(safe_list, (list, tuple))

--- a/cadnano/views/sliceview/nucleicacidpartitem.py
+++ b/cadnano/views/sliceview/nucleicacidpartitem.py
@@ -396,6 +396,8 @@ class SliceNucleicAcidPartItem(QAbstractPartItem):
 
                 assert len(self.coordinates_to_vhid.keys()) == len(set(self.coordinates_to_vhid.keys()))
                 assert len(self.coordinates_to_vhid.values()) == len(set(self.coordinates_to_vhid.values()))
+            else:
+                self.coordinates_to_vhid[coordinates] = id_num
     # end def
 
     def partVirtualHelixRemovingSlot(self, sender: NucleicAcidPart,
@@ -967,7 +969,7 @@ class SliceNucleicAcidPartItem(QAbstractPartItem):
             x_list, y_list, parity_list = zip(*path)
             id_numbers = self._model_part.batchCreateVirtualHelices(x_list=x_list,
                                                                     y_list=y_list,
-                                                                    parity=parity_list)
+                                                                    parities=parity_list)
             for id_number in id_numbers:
                 vhi = self._virtual_helix_item_hash[id_number]
                 tool.setVirtualHelixItem(vhi)


### PR DESCRIPTION
Fix a handful of bugs that were preventing the SPA mode from working in `abstract-view-engine`

To test:  open the SliceView and while holding `alt` or `option`, click on a GridPoint, then click on another GridPoint.  All VHs in the lattice between the two selected VHs should be created.  